### PR TITLE
Rename project to gcp-idleness-exporter

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,6 +35,6 @@ jobs:
           USERNAME: devbytom
           PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           DOCKERFILE: "Dockerfile"
-          IMAGE_NAME: "devbytom/gcp-idle-resources-metrics"
+          IMAGE_NAME: "devbytom/gcp-idleness-exporter"
           TAG_NAME: ${{ github.sha }}
           LATEST: "true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,6 @@ jobs:
           USERNAME: devbytom
           PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           DOCKERFILE: "Dockerfile"
-          IMAGE_NAME: "devbytom/gcp-idle-resources-metrics"
+          IMAGE_NAME: "devbytom/gcp-idleness-exporter"
           TAG_NAME: ${{ github.ref }}
           LATEST: "true"

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     version: 1.18
 repository:
-    path: github.com/7onn/gcp-idle-resources-metrics
+    path: github.com/7onn/gcp-idleness-exporter
 build:
     binaries:
         - name: server

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gcp-idle-resources-metrics
+# gcp-idleness-exporter
 Identify unused resources at Google Cloud Platform through Prometheus' metrics
 
 
@@ -56,14 +56,14 @@ cp ~/.config/gcloud/application_default_credentials.json ./credentials.json
 
 chmod 444 credentials.json
 
-docker build -t gcp-idle-resources-metrics . 
+docker build -t gcp-idleness-exporter . 
 
 docker run -it --rm --network=host \
   -v $(pwd)/credentials.json:/credentials.json \
   -e GOOGLE_APPLICATION_CREDENTIALS=/credentials.json \
   -e GCP_PROJECT_ID= \
   -e GCP_REGIONS=us-east1,us-central1,southamerica-east1 \
-  gcp-idle-resources-metrics
+  gcp-idleness-exporter
 ```
 Check the exported [metrics](http://localhost:5000/metrics).
 
@@ -77,10 +77,10 @@ helm search repo 7onn
 
 Export its default values
 ```bash
-helm show values 7onn/gcp-idle-resources-metrics > values.yaml
+helm show values 7onn/gcp-idleness-exporter > values.yaml
 ```
 
 Edit the values according to your needs then install the application
 ```bash
-helm upgrade -i gcp-idle-resources-metrics --values values.yaml 7onn/gcp-idle-resources-metrics
+helm upgrade -i gcp-idleness-exporter --values values.yaml 7onn/gcp-idleness-exporter
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/7onn/gcp-idle-resources-metrics
+module github.com/7onn/gcp-idleness-exporter
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"cloud.google.com/go/compute/metadata"
-	"github.com/7onn/gcp-idle-resources-metrics/collector"
+	"github.com/7onn/gcp-idleness-exporter/collector"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/promlog"
@@ -125,7 +125,7 @@ func main() {
 
 	promlogConfig := &promlog.Config{}
 	flag.AddFlags(kingpin.CommandLine, promlogConfig)
-	kingpin.Version(version.Print("gcp-idle-resources-metrics"))
+	kingpin.Version(version.Print("gcp-idleness-exporter"))
 	kingpin.CommandLine.UsageWriter(os.Stdout)
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
@@ -141,10 +141,10 @@ func main() {
 	if *disableDefaultCollectors {
 		collector.DisableDefaultCollectors()
 	}
-	level.Info(logger).Log("msg", "Starting gcp-idle-resources-metrics", "version", version.Info())
+	level.Info(logger).Log("msg", "Starting gcp-idleness-exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", "build_context", version.BuildContext())
 	if user, err := user.Current(); err == nil && user.Uid == "0" {
-		level.Warn(logger).Log("msg", "gcp-idle-resources-metrics is running as root user. This exporter is designed to run as unpriviledged user, root is not required.")
+		level.Warn(logger).Log("msg", "gcp-idleness-exporter is running as root user. This exporter is designed to run as unpriviledged user, root is not required.")
 	}
 
 	// Detect Project ID


### PR DESCRIPTION
**Why is this pull request necessary, and what does it do**?
To rename this repository and the application module to `gcp-idleness-exporter`.

**Special notes for your reviewer**:
https://github.com/7onn/gcp-idle-resources-metrics/issues/17