### PR TITLE
Improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,12 @@ Current supported APIs:
 
 To enable only some specific collector(s):
 ```bash
-./server --collector.disable-defaults --collector.gce_is_disk_attached --collector.gce_is_old_snapshot
+./server --collector.disable-defaults --collector.gce_is_disk_attached --collector.gce_disk_snapshot
 ```
+
+
+## Available metrics
+Visit our [wiki](https://github.com/7onn/gcp-idleness-exporter/wiki/Available-metrics) for more information.
 
 
 ### Docker

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -17,13 +17,13 @@ import (
 var (
 	scrapeDurationDesc = prometheus.NewDesc(
 		prometheus.BuildFQName("gcp", "scrape", "collector_duration_seconds"),
-		"gcp_idle_resources_metrics: Duration of a collector scrape.",
+		"gcp_idleness_exporter: Duration of a collector scrape.",
 		[]string{"collector"},
 		nil,
 	)
 	scrapeSuccessDesc = prometheus.NewDesc(
 		prometheus.BuildFQName("gcp", "scrape", "collector_success"),
-		"gcp_idle_resources_metrics: Whether a collector succeeded.",
+		"gcp_idleness_exporter: Whether a collector succeeded.",
 		[]string{"collector"},
 		nil,
 	)
@@ -156,6 +156,9 @@ func execute(name string, c Collector, ch chan<- prometheus.Metric, logger log.L
 type Collector interface {
 	// Get new metrics and expose them via prometheus registry.
 	Update(ch chan<- prometheus.Metric) error
+
+	// List available metrics
+	ListMetrics() []string
 }
 
 // ErrNoData indicates the collector found no data to collect, but had no other error.

--- a/collector/dataproc_is_cluster_running.go
+++ b/collector/dataproc_is_cluster_running.go
@@ -28,6 +28,10 @@ func init() {
 	registerCollector("dataproc_is_cluster_running", defaultEnabled, NewDataprocIsClusterRunningCollector)
 }
 
+func (e *DataprocIsClusterRunningCollector) ListMetrics() []string {
+	return []string{"dataproc_is_cluster_running"}
+}
+
 func NewDataprocIsClusterRunningCollector(logger log.Logger, project string, monitoredRegions []string) (Collector, error) {
 	ctx := context.Background()
 	gcpClient, err := NewGCPClient(ctx, dataproc.CloudPlatformScope)

--- a/collector/dataproc_is_cluster_running_test.go
+++ b/collector/dataproc_is_cluster_running_test.go
@@ -1,0 +1,22 @@
+package collector
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDataprocIsClusterRunningCollectorListMetrics(t *testing.T) {
+	cases := []struct {
+		desc     string
+		expected []string
+	}{
+		{"should list available metrics for dataproc_is_cluster_running collector", []string{"dataproc_is_cluster_running"}},
+	}
+
+	for _, tc := range cases {
+		collector := DataprocIsClusterRunningCollector{}
+		if !reflect.DeepEqual(collector.ListMetrics(), tc.expected) {
+			t.Errorf("expected %s got %+v", tc.expected, collector.ListMetrics())
+		}
+	}
+}

--- a/collector/gce_disk_snapshot.go
+++ b/collector/gce_disk_snapshot.go
@@ -24,11 +24,16 @@ func init() {
 	registerCollector("gce_disk_snapshot", defaultEnabled, NewGCEDiskSnapshotCollector)
 }
 
+func (e *GCEDiskSnapshotCollector) ListMetrics() []string {
+	return []string{"gce_disk_snapshot_age_days", "gce_disk_snapshot_amount"}
+}
+
 type GCEDiskSnapshotCollector struct {
 	logger           log.Logger
 	service          *compute.Service
 	project          string
 	monitoredRegions []string
+	metrics          []string
 	mutex            sync.RWMutex
 }
 
@@ -49,6 +54,7 @@ func NewGCEDiskSnapshotCollector(logger log.Logger, project string, monitoredReg
 		service:          computeService,
 		project:          project,
 		monitoredRegions: monitoredRegions,
+		metrics:          []string{"gce_disk_snapshot_amount", "gce_disk_snapshot_age_days"},
 	}, nil
 }
 

--- a/collector/gce_disk_snapshot_test.go
+++ b/collector/gce_disk_snapshot_test.go
@@ -1,0 +1,22 @@
+package collector
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGCEDiskSnapshotCollectorListMetrics(t *testing.T) {
+	cases := []struct {
+		desc     string
+		expected []string
+	}{
+		{"should list available metrics for gce_disk_snapshot collector", []string{"gce_disk_snapshot_age_days", "gce_disk_snapshot_amount"}},
+	}
+
+	for _, tc := range cases {
+		collector := GCEDiskSnapshotCollector{}
+		if !reflect.DeepEqual(collector.ListMetrics(), tc.expected) {
+			t.Errorf("expected %s got %+v", tc.expected, collector.ListMetrics())
+		}
+	}
+}

--- a/collector/gce_is_disk_attached.go
+++ b/collector/gce_is_disk_attached.go
@@ -29,6 +29,10 @@ func init() {
 	registerCollector("gce_is_disk_attached", defaultEnabled, NewIsDiskAttachedCollector)
 }
 
+func (e *GCEIsDiskAttachedCollector) ListMetrics() []string {
+	return []string{"gce_is_disk_attached"}
+}
+
 func NewIsDiskAttachedCollector(logger log.Logger, project string, monitoredRegions []string) (Collector, error) {
 	ctx := context.Background()
 	gcpClient, err := NewGCPClient(ctx, compute.ComputeReadonlyScope)

--- a/collector/gce_is_disk_attached_test.go
+++ b/collector/gce_is_disk_attached_test.go
@@ -1,0 +1,22 @@
+package collector
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGCEIsDiskAttachedCollectorListMetrics(t *testing.T) {
+	cases := []struct {
+		desc     string
+		expected []string
+	}{
+		{"should list available metrics for gce_is_disk_attached collector", []string{"gce_is_disk_attached"}},
+	}
+
+	for _, tc := range cases {
+		collector := GCEIsDiskAttachedCollector{}
+		if !reflect.DeepEqual(collector.ListMetrics(), tc.expected) {
+			t.Errorf("expected %s got %+v", tc.expected, collector.ListMetrics())
+		}
+	}
+}

--- a/collector/gce_is_machine_running.go
+++ b/collector/gce_is_machine_running.go
@@ -29,6 +29,10 @@ func init() {
 	registerCollector("gce_is_machine_running", defaultEnabled, NewGCEIsMachineRunningCollector)
 }
 
+func (e *GCEIsMachineRunningCollector) ListMetrics() []string {
+	return []string{"gce_is_machine_running"}
+}
+
 func NewGCEIsMachineRunningCollector(logger log.Logger, project string, monitoredRegions []string) (Collector, error) {
 	ctx := context.Background()
 	gcpClient, err := NewGCPClient(ctx, compute.ComputeReadonlyScope)

--- a/collector/gce_is_machine_running_test.go
+++ b/collector/gce_is_machine_running_test.go
@@ -1,0 +1,22 @@
+package collector
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGCEIsMachineRunningCollectorListMetrics(t *testing.T) {
+	cases := []struct {
+		desc     string
+		expected []string
+	}{
+		{"should list available metrics for gce_is_machine_running collector", []string{"gce_is_machine_running"}},
+	}
+
+	for _, tc := range cases {
+		collector := GCEIsMachineRunningCollector{}
+		if !reflect.DeepEqual(collector.ListMetrics(), tc.expected) {
+			t.Errorf("expected %s got %+v", tc.expected, collector.ListMetrics())
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"os/user"
-	"sort"
 	"strings"
 
 	stdlog "log"
@@ -90,20 +89,14 @@ func (h *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		level.Error(h.logger).Log("msg", "couldn't create collector", "err", err)
 	}
 
-	level.Info(h.logger).Log("msg", "Enabled collectors")
-	collectors := []string{}
-	for n := range gcpCollector.Collectors {
-		collectors = append(collectors, n)
-	}
-	sort.Strings(collectors)
-	for _, c := range collectors {
-		level.Info(h.logger).Log("collector", c)
+	for n, c := range gcpCollector.Collectors {
+		level.Info(h.logger).Log("collector", n, "metrics", fmt.Sprintf("%+v", c.ListMetrics()))
 	}
 
 	pr := prometheus.NewRegistry()
-	pr.MustRegister(version.NewCollector("gcp_idle_resources_metrics"))
+	pr.MustRegister(version.NewCollector("gcp_idleness_exporter"))
 	if err = pr.Register(gcpCollector); err != nil {
-		level.Error(h.logger).Log("msg", "couldn't register gcp_idle_resources_metrics collector", "err", err)
+		level.Error(h.logger).Log("msg", "couldn't register gcp_idleness_exporter collector", "err", err)
 	}
 	handler := promhttp.HandlerFor(
 		prometheus.Gatherers{h.exporterMetricsRegistry, pr},


### PR DESCRIPTION
**Why is this pull request necessary, and what does it do**?
Logs are now like this:
```bash
ts=2022-05-01T22:13:03.466Z caller=main.go:137 level=info msg="Starting gcp-idleness-exporter" version="(version=, branch=, revision=)"
ts=2022-05-01T22:13:03.466Z caller=main.go:138 level=info msg="Build context" build_context="(go=go1.18, user=, date=)"
ts=2022-05-01T22:13:03.466Z caller=main.go:175 level=info msg="Starting exporter for project REDACTED at [us-central1 us-east1 southamerica-east1]"
ts=2022-05-01T22:13:03.466Z caller=main.go:177 level=info msg="Listening on :5000"
ts=2022-05-01T22:14:46.254Z caller=main.go:93 level=info collector=gce_disk_snapshot metrics="[gce_disk_snapshot_age_days gce_disk_snapshot_amount]"
ts=2022-05-01T22:14:46.254Z caller=main.go:93 level=info collector=gce_is_disk_attached metrics=[gce_is_disk_attached]
ts=2022-05-01T22:14:46.254Z caller=main.go:93 level=info collector=gce_is_machine_running metrics=[gce_is_machine_running]
ts=2022-05-01T22:14:46.254Z caller=main.go:93 level=info collector=dataproc_is_cluster_running metrics=[dataproc_is_cluster_running]
```

**Special notes for your reviewer**:
https://github.com/7onn/gcp-idleness-exporter/issues/19