### PR TITLE
Bump go version to 1.19

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,5 +1,5 @@
 go:
-    version: 1.18
+    version: 1.19
 repository:
     path: github.com/7onn/gcp-idleness-exporter
 build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.0-buster AS build
+FROM golang:1.19.0-buster AS build
 WORKDIR /app
 COPY go.mod ./
 COPY go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/7onn/gcp-idleness-exporter
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/compute v1.19.0


### PR DESCRIPTION
**Why is this pull request necessary, and what does it do**?
To bring Golang near to its LTS.

**Special notes for your reviewer**:
